### PR TITLE
Fix: Use only first succesfully loaded library

### DIFF
--- a/python/distorm3/__init__.py
+++ b/python/distorm3/__init__.py
@@ -43,6 +43,7 @@ for i in potential_libs:
         _distorm_file = join(_distorm_path, i)
         _distorm = cdll.LoadLibrary(_distorm_file)
         lib_was_found = True
+        break
     except OSError:
         pass
 


### PR DESCRIPTION
I keep both windows and linux dinamic libraries on the distorm3 directory for convinience, on linux works fine but on windows python launchs an alert when it tries to load the linux .so library, this could be avoid by leaving the for loop after the first successful load.
Here is the error screenshot:
![distorm3](https://cloud.githubusercontent.com/assets/8166442/10510705/c60cfb98-7334-11e5-9582-4601153453a6.png)
Thanks!