### PR TITLE
more distribution friendly Makefile improvements

### DIFF
--- a/make/linux/Makefile
+++ b/make/linux/Makefile
@@ -5,7 +5,10 @@
 TARGET	= libdistorm3.so
 COBJS	= ../../src/mnemonics.o ../../src/wstring.o ../../src/textdefs.o ../../src/prefix.o ../../src/operands.o ../../src/insts.o ../../src/instructions.o ../../src/distorm.o ../../src/decoder.o
 CC	= gcc
-CFLAGS	= -fPIC -O2 -Wall -DSUPPORT_64BIT_OFFSET -DDISTORM_STATIC
+CFLAGS	+= -fPIC -O2 -Wall -DSUPPORT_64BIT_OFFSET -DDISTORM_STATIC
+LDFLAGS	+= -shared
+PREFIX	= /usr/local
+DESTDIR	=
 
 all: clib
 
@@ -13,11 +16,11 @@ clean:
 	/bin/rm -rf ../../src/*.o ${TARGET} ../../distorm3.a ./../*.o
 
 clib: ${COBJS}
-	${CC} ${CFLAGS} ${VERSION} ${COBJS} -shared -o ${TARGET}
+	${CC} ${CFLAGS} ${VERSION} ${COBJS} ${LDFLAGS} -o ${TARGET}
 	ar rs ../../distorm3.a ${COBJS}
 
 install: libdistorm3.so
-	install -s ${TARGET} /usr/local/lib
+	install -D -s ${TARGET} ${DESTDIR}/${PREFIX}/lib/${TARGET}
 	@echo "... running ldconfig might be smart ..."
 
 .c.o:


### PR DESCRIPTION
- append CFLAGS instead of force-set it, this was distributions
  can also add their own CFLAGS in addition (this is very common).
- introduce LDFLAGS so distributions can set their own additional
  flags for the linker and append instead of set (this is very common)
- replace static /usr/local/lib with a PREFIX variable with default
  value of /usr/local so a distribution can easily use PREFIX=/usr
  (this is also common)
- introduce DESTDIR for distribution wide packaging as they build in
  chroots and deploy into a special directory structure that will later
  put into a tarball and lands in a distribution package.
  f.e. DESTDIR="/build/package" (this is also common for packaging)
- adding -D to install call to create all leading components of the
  destination. This is very important if the DESTDIR is set for
  packaging the therefor the structure does not yet exists. This will
  then basically freate the directory structure. in case DESTDIR is not
  used and /usr/local/lib f.e. already exists this will do nothing
  this is highly common to do it this way.
  We add the ${TARGET} to the end because we use the -D parameter and
  therefor we need to also pass the resulting filename