### PR TITLE
VS14 wants /DLL in link command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ def main():
                                 '"/D _MBCS"', '/GF', '/Gm', '/Zi', '/EHsc',
                                 '/MT', '/Gy', '/W4', '/nologo', '/c', '/TC',
                                 '/Fdbuild\\vc90.pdb'],
-            extra_link_args=['/MANIFEST']))]
+            extra_link_args=['/MANIFEST', '/DLL']))]
     elif 'darwin' in system or 'macosx' in system:
         libraries = [(
             'distorm3', dict(


### PR DESCRIPTION
Without it, the command-line only "[Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159)" reports "LINK : fatal error LNK1561: entry point must be defined" and fails to link.

I have built windows_amd64 binaries for Python 3.5, which can be downloaded from
[http://content.iegrec.org/python/distorm/distorm3-3.3.4+jm.win-amd64.zip](url)
[http://content.iegrec.org/python/distorm/distorm3-3.3.4+jm.win-amd64.exe](url)
