### PR TITLE
Fix a typo in Python setup error handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class custom_build_clib(build_clib):
         if (sources is None or
             type(sources) not in (list, tuple) or
             len(sources) == 0):
-            raise DistutilsSetupError ("in 'libraries' option (library '%s'), 'sources' must be present and must be a list of source filenames") % lib_name
+            raise DistutilsSetupError ("in 'libraries' option (library '%s'), 'sources' must be present and must be a list of source filenames" % lib_name)
         return sources
 
     def get_source_files(self):

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,10 @@ class custom_build_clib(build_clib):
         if (sources is None or
             type(sources) not in (list, tuple) or
             len(sources) == 0):
-            raise DistutilsSetupError ("in 'libraries' option (library '%s'), 'sources' must be present and must be a list of source filenames" % lib_name)
+            raise DistutilsSetupError(
+                "in 'libraries' option (library '%s'), 'sources' must be "
+                "present and must be a list of source filenames" % lib_name
+            )
         return sources
 
     def get_source_files(self):


### PR DESCRIPTION
If the ```setup.py``` script couldn't for some reason get a list of source files, it failed with the following exception:

```
>setup.py build
running build
running custom_build
running build_py
running build_clib
running custom_build_clib
Traceback (most recent call last):
  File "setup.py", line 266, in <module>
    main()
  File "setup.py", line 263, in main
    setup(**options)
  File "C:\Program Files (x86)\python27\lib\distutils\core.py", line 151, in setup
    dist.run_commands()
  File "C:\Program Files (x86)\python27\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "C:\Program Files (x86)\python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "setup.py", line 43, in run
    build.run(self)
  File "C:\Program Files (x86)\python27\lib\distutils\command\build.py", line 127, in run
    self.run_command(cmd_name)
  File "C:\Program Files (x86)\python27\lib\distutils\cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "C:\Program Files (x86)\python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "setup.py", line 95, in run
    build_clib.run(self)
  File "C:\Program Files (x86)\python27\lib\distutils\command\build_clib.py", line 116, in run
    self.build_libraries(self.libraries)
  File "setup.py", line 99, in build_libraries
    sources = self.get_source_files_for_lib(lib_name, build_info)
  File "setup.py", line 82, in get_source_files_for_lib
    raise DistutilsSetupError ("in 'libraries' option (library '%s'), 'sources' must be present and must be a list of source filenames") % lib_name
TypeError: unsupported operand type(s) for %: 'DistutilsSetupError' and 'str'
```

This can be demonstrated by setting the sources list empty:

```diffb
diff --git a/setup.py b/setup.py
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@
         libraries = [(
             'distorm3', dict(
             package='distorm3',
-            sources=get_sources,
+            sources=[],
             include_dirs=['src', 'include'],
             extra_compile_args=['/Ox', '/Ob1', '/Oy', '"/D WIN32"',
                                 '"/D DISTORM_DYNAMIC"', '"/D SUPPORT_64BIT_OFFSET"',
```

After the fix an error message is displayed instead of a stack trace:

```
>setup.py build
running build
running custom_build
running build_py
running build_clib
running custom_build_clib
error: in 'libraries' option (library 'distorm3'), 'sources' must be present and must be a list of source filenames
```
