### PR TITLE
Bug parsing privileged instructions

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -91,7 +91,7 @@ static _DecodeResult decode_inst(_CodeInfo* ci, _PrefixState* ps, _DInst* di)
 
 	/* Holds the info about the current found instruction. */
 	_InstInfo* ii = NULL;
-	_InstInfo ii_c;
+	_InstInfo iip; /* Privileged instruction cache. */
 	_InstSharedInfo* isi = NULL;
 
 	/* Used only for special CMP instructions which have pseudo opcodes suffix. */
@@ -114,15 +114,15 @@ static _DecodeResult decode_inst(_CodeInfo* ci, _PrefixState* ps, _DInst* di)
 	instFlags = FlagsTable[isi->flagsIndex];
 	privilegedFlag = ii->opcodeId & OPCODE_ID_PRIVILEGED;
 
-	if ( privilegedFlag ) {
+	if (privilegedFlag) {
 		/*
 		 * Copy the privileged instruction info so we can remove the privileged bit
-		 * from the opcodeId field ASAP. This makes sure we're not modifying what's
-		 * in the tables in case we lookup another privileged instruction later
+		 * from the opcodeId field. This makes sure we're not modifying the tables
+		 * in case we lookup this privileged instruction later.
 		 */
-		ii_c = *ii;
-		ii_c.opcodeId &= ~OPCODE_ID_PRIVILEGED;
-		ii = &ii_c;
+		iip = *ii;
+		iip.opcodeId &= ~OPCODE_ID_PRIVILEGED;
+		ii = &iip;
 	}
 
 	/*

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -91,6 +91,7 @@ static _DecodeResult decode_inst(_CodeInfo* ci, _PrefixState* ps, _DInst* di)
 
 	/* Holds the info about the current found instruction. */
 	_InstInfo* ii = NULL;
+	_InstInfo ii_c;
 	_InstSharedInfo* isi = NULL;
 
 	/* Used only for special CMP instructions which have pseudo opcodes suffix. */
@@ -111,10 +112,18 @@ static _DecodeResult decode_inst(_CodeInfo* ci, _PrefixState* ps, _DInst* di)
 	if (ii == NULL) goto _Undecodable;
 	isi = &InstSharedInfoTable[ii->sharedIndex];
 	instFlags = FlagsTable[isi->flagsIndex];
-
-	/* Copy the privileged bit and remove it from the opcodeId field ASAP. */
 	privilegedFlag = ii->opcodeId & OPCODE_ID_PRIVILEGED;
-	ii->opcodeId &= ~OPCODE_ID_PRIVILEGED;
+
+	if ( privilegedFlag ) {
+		/*
+		 * Copy the privileged instruction info so we can remove the privileged bit
+		 * from the opcodeId field ASAP. This makes sure we're not modifying what's
+		 * in the tables in case we lookup another privileged instruction later
+		 */
+		ii_c = *ii;
+		ii_c.opcodeId &= ~OPCODE_ID_PRIVILEGED;
+		ii = &ii_c;
+	}
 
 	/*
 	 * If both REX and OpSize are available we will have to disable the OpSize, because REX has precedence.


### PR DESCRIPTION
Code was permanently wacking the instructions opcodeId when we cleared the privileged flag. This should fix that by making a copy (ick?) that we modify instead. Should keep the function re-entrant (assuming there are no other problems) vs just fixing up the opcodeId when we're done.