### PR TITLE
sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def get_sources():
     create the libdistorm3 library.
     """
 
-    return glob('src/*.c')
+    return sorted(glob('src/*.c'))
 
 
 class custom_build(build):


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.