### PR TITLE
[WIN] added automatic detection of win64 setup.py; quickly find vcvars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,10 @@ def compile_vc(solution_path, config, platform):
     # Try a super-quick method to find vcvarsall.bat
     try:
         bat = quick_get_vcvars()
-        log.info('Compiling with %s' % bat)
-        sp.check_call(['call', bat, 'x86_amd64' if platform=='x64' else 'x86', '&&'] + msbuild, shell = True)
-        return
+        if bat is not None:
+            log.info('Compiling with %s' % bat)
+            sp.check_call(['call', bat, 'x86_amd64' if platform=='x64' else 'x86', '&&'] + msbuild, shell = True)
+            return
     except sp.CalledProcessError:
         log.info('compilation with vswhere failed')
 


### PR DESCRIPTION
I can't test this for ancient compilers, but it worked fast and well for me.

Automatically selects 32 or 64 bit based on the architecture of python executing setup.py.

This should apply to `pip` also, though `pip` based install on x64 is broken at the moment anyway.