### PR TITLE
Python build simplification

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -1,0 +1,34 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+        python-version: [2.7, 3.5]
+        exclude:
+          # This combination requires MSVC 9, which is difficult here
+          - os: windows-latest
+            python-version: 2.7
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Build and install package
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python setup.py bdist_wheel
+        pip install --find-links=dist --no-index distorm3
+    - uses: actions/upload-artifact@v1
+      with:
+        name: Wheels
+        path: dist
+    - name: Test importing
+      run: python -c 'import distorm3'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.egg-info
+*.py[cod]
+*.so
+build
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include COPYING setup.cfg setup.py
 include make\win32\cdistorm.vcxproj make\win32\cdistorm.vcxproj.filters make\win32\distorm.sln make\win32\resource.h make\win32\Resource.rc
 recursive-include src *.c *.h
-recursive-include include *.c *.h
+recursive-include include *.h
 recursive-include . *.py

--- a/python/python_module_init.c
+++ b/python/python_module_init.c
@@ -1,0 +1,30 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#if PY_MAJOR_VERSION == 2
+PyMODINIT_FUNC
+init_distorm3(void)
+{
+    (void) Py_InitModule("_distorm3", NULL);
+}
+#else
+static struct PyModuleDef _distorm3_module = {
+    PyModuleDef_HEAD_INIT,
+    "_distorm3",
+    NULL,
+    -1,
+    NULL,
+};
+
+PyMODINIT_FUNC
+PyInit__distorm3(void)
+{
+    PyObject *m;
+
+    m = PyModule_Create(&_distorm3_module);
+    if (m == NULL)
+        return NULL;
+
+    return m;
+}
+#endif

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [install]
 force=1
 compile=1

--- a/setup.py
+++ b/setup.py
@@ -7,251 +7,11 @@
 # Licensed under BSD.
 #
 
-__revision__ = "$Id: setup.py 603 2010-01-31 00:11:05Z qvasimodo $"
-
-import re
 import os
 import os.path
-import platform
-import string
-import shutil
-import sys
-import subprocess as sp
-import struct
-
 from glob import glob
-from shutil import ignore_patterns
-from setuptools import dist
-from distutils import log
-from distutils.command.build import build
-from distutils.command.build_clib import build_clib
-from distutils.command.clean import clean
-from setuptools.command.install import install
-from distutils.command.install_lib import install_lib
-from distutils.command.sdist import sdist
-from distutils.core import setup, Extension
-from distutils.errors import DistutilsSetupError
+from setuptools import Extension, setup
 
-def quick_get_vcvars():
-    try:
-        vswhere = os.fsdecode(sp.check_output(r"echo %ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe", shell=1).strip())
-        print("vswhere: {}".format(vswhere))
-        installationPath = os.fsdecode(sp.check_output(r"{} -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath".format(vswhere)).strip())
-        print("installationPath: {}".format(installationPath))
-        vcvars = installationPath + r"\vc\Auxiliary\Build\vcvarsall.bat"
-        print("vcvars: {}".format(vcvars))
-        if os.path.exists(vcvars):
-            return vcvars
-    except sp.CalledProcessError:
-        log.info('quick_get_vcvars() failed to locate vcvarsall.bat path')
-
-def scanfor_vc_all():
-    fname = "vcvarsall.bat"
-    startDir = "C:\\Program Files (x86)\\Microsoft Visual Studio\\"
-    print("searching for %s" % fname)
-    for dirpath, dirnames, filenames in os.walk(startDir):
-        for f in filenames:
-            if f == fname:
-                return os.path.join(dirpath, f)
-
-def compile_vc(solution_path, config, platform):
-    match_vs = re.compile('vs(\d+)comntools$', re.I).match
-    compilers = [
-        m.group(1, 0) for m in (match_vs(k) for k in os.environ.keys())
-        if m is not None
-    ]
-    msbuild = [
-        'msbuild',
-            '/p:Configuration=%s' % config,
-            '/p:Platform=%s' % platform,
-            solution_path
-    ]
-    # Try a super-quick method to find vcvarsall.bat
-    try:
-        bat = quick_get_vcvars()
-        if bat is not None:
-            log.info('Compiling with %s' % bat)
-            sp.check_call(['call', bat, 'x86_amd64' if platform=='x64' else 'x86', '&&'] + msbuild, shell = True)
-            return
-    except sp.CalledProcessError:
-        log.info('compilation with vswhere failed')
-
-    # Else, proceed with the previous scheme...
-    for ver, var in sorted(compilers, key = lambda v: -int(v[0])):
-        bat = os.path.join(os.environ[var], r'..\..\vc\vcvarsall.bat')
-        try:
-            log.info('Compiling with %s: %s', var, ' '.join(msbuild))
-            sp.check_call(['call', bat, '&&'] + msbuild, shell = True)
-            return
-        except sp.CalledProcessError:
-            log.info('compilation with %s failed', var)
-    # Try brute force find the batch file for VS env
-    try:
-        bat = scanfor_vc_all()
-        log.info('Compiling with %s' % bat)
-        sp.check_call(['call', bat, 'x86_amd64' if platform=='x64' else 'x86', '&&'] + msbuild, shell = True)
-        return
-    except sp.CalledProcessError:
-        log.info('compilation failed')
-
-    raise DistutilsSetupError(
-        'Failed to compile "%s" with any available compiler' % solution_path
-    )
-
-def get_sources():
-    """Returns a list of C source files that should be compiled to 
-    create the libdistorm3 library.
-    """
-    return sorted(glob('src/*.c'))
-
-class custom_build(build):
-    """Customized build command"""
-    def run(self):
-        log.info('running custom_build')
-        if 'windows' in platform.system().lower():
-            bits = 'win32' # x86 by default
-            bitsize = 8 * struct.calcsize("P")
-            if bitsize == 32:
-                bits = 'win32'
-            elif bitsize == 64:
-                bits = 'x64'
-            # If win32/x64 is specified in command line, change it here
-            for i in sys.argv:
-                if i.find("--plat-name=win-amd64") != -1:
-                     bits = 'x64'
-                if i.find("--plat-name=win32") != -1:
-                     bits = 'win32'
-            compile_vc('make/win32/distorm.sln', 'dll', bits)
-            self.copy_file('distorm3.dll', 'python/distorm3')
-        build.run(self)
-
-class custom_build_clib(build_clib):
-    """Customized build_clib command
-
-    This custom_build_clib will create dynamically linked libraries rather 
-    than statically linked libraries.  In addition, it places the compiled 
-    libraries alongside the python packages, to facilitate the use of ctypes. 
-    """
-
-    def finalize_options(self):
-        # We want build-clib to default to build-lib as defined by the 
-        # "build" command.  This is so the compiled library will be put 
-        # in the right place along side the python code.
-        self.set_undefined_options('build',
-                                   ('build_lib', 'build_clib'),
-                                   ('build_temp', 'build_temp'),
-                                   ('compiler', 'compiler'),
-                                   ('debug', 'debug'),
-                                   ('force', 'force'))
-
-        self.libraries = self.distribution.libraries
-        if self.libraries: # In Python 3.0 they have a bug in check_library_list, comment it out then.
-            self.check_library_list(self.libraries)
-
-        if self.include_dirs is None:
-            self.include_dirs = self.distribution.include_dirs or []
-        if type(self.include_dirs) in (bytes, str):
-            self.include_dirs = string.split(self.include_dirs,
-                                             os.pathsep)
-
-    def get_source_files_for_lib(self, lib_name, build_info):
-        sources = build_info.get('sources', [])
-        if hasattr(sources, '__call__'):
-            sources = sources()
-        if (sources is None or
-            type(sources) not in (list, tuple) or
-            len(sources) == 0):
-            raise DistutilsSetupError(
-                "in 'libraries' option (library '%s'), 'sources' must be "
-                "present and must be a list of source filenames" % lib_name
-            )
-        return sources
-
-    def get_source_files(self):
-        self.check_library_list(self.libraries)
-        filenames = []
-        for (lib_name, build_info) in self.libraries:
-            sources = self.get_source_files_for_lib(lib_name, build_info)
-            filenames.extend(sources)
-        return filenames
-
-    def run(self):
-        log.info('running custom_build_clib')
-        build_clib.run(self)
-
-    def build_libraries(self, libraries):
-        for (lib_name, build_info) in libraries:
-            sources = self.get_source_files_for_lib(lib_name, build_info)
-            sources = list(sources)
-
-            log.info("building '%s' library", lib_name)
-
-            # First, compile the source code to object files in the 
-            # library directory.
-            macros = build_info.get('macros')
-            include_dirs = build_info.get('include_dirs')
-            objects = self.compiler.compile(sources,
-                output_dir=self.build_temp,
-                macros=macros,
-                include_dirs=include_dirs,
-                extra_postargs=build_info.get('extra_compile_args', []),
-                debug=self.debug)
-
-            # Then link the object files and put the result in the 
-            # package build directory.
-            package = build_info.get('package', '')
-            self.compiler.link_shared_lib(
-                objects, lib_name,
-                output_dir=os.path.join(self.build_clib, package),
-                extra_postargs=build_info.get('extra_link_args', []),
-                debug=self.debug,)
-
-
-class custom_clean(clean):
-    """Customized clean command
-
-    Customized clean command removes .pyc files from the project, 
-    as well as build and dist directories."""
-    def run(self):
-        log.info('running custom_clean')
-        # Remove .pyc files
-        if hasattr(os, 'walk'):
-            for root, dirs, files in os.walk('.'):
-                for f in files:
-                    if f.endswith('.pyc'):
-                        log.info("removing '%s'" % f)
-                        try:
-                            os.unlink(f)
-                        except:
-                            pass
-
-        # Remove generated directories
-        for dir in ['build', 'dist', 'make/win32/.vs', 'make/win32/dll', 'make/win32/x64', 'python/distorm3.egg-info']:
-            if os.path.exists(dir):
-                log.info("removing '%s' (and everything under it)"%dir)
-                try:
-                    shutil.rmtree(dir, ignore_errors=True)
-                except:
-                    pass
-
-        clean.run(self)
-
-class custom_sdist(sdist):
-    """Customized sdist command"""
-    def run(self):
-        log.info('running custom_sdist')
-        sdist.run(self)
-
-class BinaryDistribution(dist.Distribution):
-    def is_pure(self):
-        return False
-    def has_ext_modules(self):
-        return True
-
-class custom_install(install):
-    def finalize_options(self):
-        install.finalize_options(self)
-        self.install_lib = self.install_platlib
 
 def main():
     # Just in case we are being called from a different directory
@@ -259,44 +19,13 @@ def main():
     if cwd:
         os.chdir(cwd)
 
-    # Get the target platform
-    system  = platform.system().lower()
-
-    # Setup the extension module
-    # Setup the library
-    ext_modules = None
-    libraries = None
     package_data = []
-    if 'windows' in system:
-        package_data = ['distorm3.dll']
-    elif 'darwin' in system or 'macosx' in system:
-        libraries = [(
-            'distorm3', dict(
-            package='distorm3',
-            sources=get_sources,
-            include_dirs=['src', 'include'],
-            extra_compile_args=['-arch', 'i386', '-arch', 'x86_64', '-O2',
-                                '-Wall', '-fPIC', '-DSUPPORT_64BIT_OFFSET',
-                                '-DDISTORM_DYNAMIC']))]
-    elif 'cygwin' in system:
-        libraries = [(
-            'distorm3', dict(
-            package='distorm3',
-            sources=get_sources,
-            include_dirs=['src', 'include'],
-            extra_compile_args=['-fPIC', '-O2', '-Wall',
-                                '-DSUPPORT_64BIT_OFFSET',
-                                '-DDISTORM_STATIC']))]
-    else:
-        libraries = [(
-            'distorm3', dict(
-            package='distorm3',
-            sources=get_sources,
-            include_dirs=['src', 'include'],
-            extra_link_args=['-Wl,-soname,libdistorm3.so.3'],
-            extra_compile_args=['-fPIC', '-O2', '-Wall',
-                                '-DSUPPORT_64BIT_OFFSET',
-                                '-DDISTORM_STATIC']))]
+    distorm_module = Extension(
+        "_distorm3",
+        sources=sorted(glob('src/*.c')) + ["python/python_module_init.c"],
+        include_dirs=['src', 'include'],
+        define_macros=[('SUPPORT_64BIT_OFFSET', None), ('DISTORM_DYNAMIC', None)],
+    )
 
     options = {
 
@@ -305,15 +34,8 @@ def main():
     'provides'          : ['distorm3'],
     'packages'          : ['distorm3'],
     'package_dir'       : { '' : 'python' },
-    'cmdclass'          : { 'build' : custom_build,
-                            'build_clib' : custom_build_clib,
-                            'clean' : custom_clean, 
-                            'sdist' : custom_sdist,
-                            'install' : custom_install },
-    'libraries'         : libraries,
+    'ext_modules'       : [distorm_module],
     'package_data'      : {'distorm3': package_data},
-    'distclass'         : BinaryDistribution,
-
     # Metadata
     'name'              : 'distorm3',
     'version'           : '3.4.1',


### PR DESCRIPTION
This PR radically changes how the Python module is built.

Instead of having distutils hacks to build a .dll, we leverage setuptools' Extension building mechanism, which gets rid of 300 or so lines of code (and probably addresses #124).

However, since the extension we build is essentially a dummy shared library that happens to have a dummy Python module entrypoint, we still need gentle hacks (so this probably doesn't help with #142):

* On Python 3.x, we import the module and read the module spec to find the disk path and load the extension module with `CDLL`.
* On Python 2.x (which is EOL, ahem), we walk `sys.path` to find the built extension `_distorm3.{so,dll}` and open it with `CDLL`.

In addition, there's a GitHub Actions configuration to build the binary wheels on Windows, macOS and Linux. [Some results here in my fork.](https://github.com/akx/distorm/commit/a264413ee2baee19878d5bd16b658d61bed2b84c/checks?check_suite_id=399890652) Going forward, the configuration could/should be used for better testing than just importing the module, too. :)

