### PR TITLE
Try to fix GHA tests on Windows

### DIFF
--- a/.github/workflows/py.yml
+++ b/.github/workflows/py.yml
@@ -42,4 +42,5 @@ jobs:
       run: copy test-deps\yasm-1.3.0-win64.exe python\yasm.exe
       if: runner.os == 'Windows'
     - name: Run test_distorm3.py
-      run: cd python; python test_distorm3.py
+      working-directory: ./python
+      run: python test_distorm3.py


### PR DESCRIPTION
As discussed in #146, Windows tests always passed probably due to Powershell issues.
Using the GHA `working-directory:` stanza seems to make things work.