### PR TITLE
Add stop on undecodeable

### DIFF
--- a/include/distorm.h
+++ b/include/distorm.h
@@ -398,6 +398,9 @@ typedef struct {
 #define DF_FILL_EFLAGS 0x2000
 /* The decoder will use the addrMask in CodeInfo structure instead of DF_MAXIMUM_ADDR16/32. */
 #define DF_USE_ADDR_MASK 0x4000
+/* The decoder will stop and return to the caller when an instruction couldn't be decoded */
+#define DF_STOP_ON_UNDECODEABLE 0x8000
+
 /* The decoder will stop and return to the caller when any flow control instruction was decoded. */
 #define DF_STOP_ON_FLOW_CONTROL (DF_STOP_ON_CALL | DF_STOP_ON_RET | DF_STOP_ON_SYS | DF_STOP_ON_UNC_BRANCH | DF_STOP_ON_CND_BRANCH | DF_STOP_ON_INT | DF_STOP_ON_CMOV | DF_STOP_ON_HLT)
 

--- a/python/distorm3/__init__.py
+++ b/python/distorm3/__init__.py
@@ -237,6 +237,9 @@ DF_STOP_ON_HLT  = 0x400
 DF_STOP_ON_PRIVILEGED = 0x800
 DF_SINGLE_BYTE_STEP = 0x1000
 DF_FILL_EFLAGS = 0x2000
+DF_USE_ADDR_MASK = 0x4000
+DF_STOP_ON_UNDECODEABLE = 0x8000
+
 DF_STOP_ON_FLOW_CONTROL = (DF_STOP_ON_CALL | DF_STOP_ON_RET | DF_STOP_ON_SYS | \
     DF_STOP_ON_UNC_BRANCH | DF_STOP_ON_CND_BRANCH | DF_STOP_ON_INT | DF_STOP_ON_CMOV | \
     DF_STOP_ON_HLT)
@@ -699,7 +702,7 @@ def DecomposeGenerator(codeOffset, code, dt, features = 0):
         p_code     = byref(code_buf, codeOffset - startCodeOffset)
         codeLen    = codeLen - delta
 
-        if (features & (DF_STOP_ON_FLOW_CONTROL | DF_STOP_ON_PRIVILEGED)) != 0:
+        if (features & (DF_STOP_ON_FLOW_CONTROL | DF_STOP_ON_PRIVILEGED | DF_STOP_ON_UNDECODEABLE)) != 0:
             break # User passed a stop flag.
 
 def Decompose(offset, code, type = Decode32Bits, features = 0):

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -548,6 +548,12 @@ _DecodeResult decode_internal(_CodeInfo* _ci, int supportOldIntr, _DInst result[
 				pdi->size = 1;
 				pdi->addr = codeOffset & ci.addrMask;
 				pdi = (_DInst*)((char*)pdi + diStructSize);
+				/* if was unable to decode instruction and should stop on undecodeable */
+				if (features & DF_STOP_ON_UNDECODEABLE) {
+					ret = DECRES_SUCCESS;
+					break;
+				}
+
 			}
 
 			/* Skip a single byte in case of a failure and retry instruction. */


### PR DESCRIPTION
Hey there!
I added the ability to stop on an undecodeable instruction, hopefully you'll find it useful.
The main idea is when trying to disassemble functions, some of the function don't end in RET or other flow control flags distorm currently supports. So instead of only limiting yourself by number of instructions, stopping on an undecodeable instruction let's you know that you probably already reached the end.
Let me know what you think :)