### PR TITLE
Make fat library optional

### DIFF
--- a/make/mac/Makefile
+++ b/make/mac/Makefile
@@ -7,7 +7,10 @@ TARGET	= libdistorm3.dylib
 PYTHON_BUILD_DIR = ../../Python/macosx-x86
 COBJS	= ../../src/mnemonics.o ../../src/textdefs.o ../../src/prefix.o ../../src/operands.o ../../src/insts.o ../../src/instructions.o ../../src/distorm.o ../../src/decoder.o
 CC	= gcc
-CFLAGS	= -arch i386 -arch x86_64 -O2 -Wall -fPIC -DSUPPORT_64BIT_OFFSET -D${DISTORM_MODE}
+CFLAGS	= -arch x86_64 -O2 -Wall -fPIC -DSUPPORT_64BIT_OFFSET -D${DISTORM_MODE}
+ifeq ($(DISTORM_FAT), 1)
+        CFLAGS += -arch i386
+endif
 
 all: clib
 


### PR DESCRIPTION
i386 is deprecated and latest toolchain doesn't operate on fat static library anymore

"warning: /Applications/Xcode9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: ../../distorm3.a will be fat and ar(1) will not be able to operate on it"