### PR TITLE
Fix python module .so file loading error

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -57,7 +57,7 @@ This library is licensed under the BSD license. See the file COPYING.
 
 #define _DLLEXPORT_
 #define _FASTCALL_
-#define _INLINE_ __inline__
+#define _INLINE_ static
 /* GCC ignores this directive... */
 /*#define _FASTCALL_ __attribute__((__fastcall__))*/
 


### PR DESCRIPTION
Fixed error: OSError: /SOMEPATH/_distorm3.so: undefined symbol: operands_set_tsi

Issue introduced in commit 7745a7c9fca40b9e7acb26e162f4e5546496710c
