### PR TITLE
added usedRegisterMask to python and RegisterMasks list

### DIFF
--- a/python/distorm3/__init__.py
+++ b/python/distorm3/__init__.py
@@ -23,12 +23,13 @@ __all__ = [
     'Decode64Bits',
     'Mnemonics',
     'Registers',
+    'RegisterMasks'
 ]
 
 from ctypes import *
 import os
 import sys
-from ._generated import Registers, Mnemonics
+from ._generated import Registers, Mnemonics, RegisterMasks
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -568,6 +569,7 @@ class Instruction (object):
             self.segment = R_NONE
             self.isSegmentDefault = False
         self.unusedPrefixesMask = di.unusedPrefixesMask
+        self.usedRegistersMask = di.usedRegistersMask
 
         if flags == FLAG_NOT_DECODABLE:
             self.mnemonic = 'DB 0x%02x' % (di.imm.byte)

--- a/python/distorm3/_generated.py
+++ b/python/distorm3/_generated.py
@@ -258,3 +258,29 @@ Registers = ["RAX", "RCX", "RDX", "RBX", "RSP", "RBP", "RSI", "RDI", "R8", "R9",
 "YMM0", "YMM1", "YMM2", "YMM3", "YMM4", "YMM5", "YMM6", "YMM7", "YMM8", "YMM9", "YMM10", "YMM11", "YMM12", "YMM13", "YMM14", "YMM15",
 "CR0", "", "CR2", "CR3", "CR4", "", "", "", "CR8",
 "DR0", "DR1", "DR2", "DR3", "", "", "DR6", "DR7"]
+
+RegisterMasks = {
+1: "RM_AX", # /* AL, AH, AX, EAX, RAX */
+2: "RM_CX", # /* CL, CH, CX, ECX, RCX */
+4: "RM_DX", # /* DL, DH, DX, EDX, RDX */
+8: "RM_BX", # /* BL, BH, BX, EBX, RBX */
+0x10: "RM_SP", # /* SPL, SP, ESP, RSP */
+0x20: "RM_BP", # /* BPL, BP, EBP, RBP */
+0x40: "RM_SI", # /* SIL, SI, ESI, RSI */
+0x80: "RM_DI", # /* DIL, DI, EDI, RDI */
+0x100: "RM_FPU", # /* ST(0) - ST(7) */
+0x200: "RM_MMX", # /* MM0 - MM7 */
+0x400: "RM_SSE", # /* XMM0 - XMM15 */
+0x800: "RM_AVX", # /* YMM0 - YMM15 */
+0x1000: "RM_CR", # /* CR0, CR2, CR3, CR4, CR8 */
+0x2000: "RM_DR", # /* DR0, DR1, DR2, DR3, DR6, DR7 */
+0x4000: "RM_R8", # /* R8B, R8W, R8D, R8 */
+0x8000: "RM_R9", # /* R9B, R9W, R9D, R9 */
+0x10000: "RM_R10", # /* R10B, R10W, R10D, R10 */
+0x20000: "RM_R11", # /* R11B, R11W, R11D, R11 */
+0x40000: "RM_R12", # /* R12B, R12W, R12D, R12 */
+0x80000: "RM_R13", # /* R13B, R13W, R13D, R13 */
+0x100000: "RM_R14", # /* R14B, R14W, R14D, R14 */
+0x200000: "RM_R15", # /* R15B, R15W, R15D, R15 */
+0x400000: "RM_SEG", # /* CS, SS, DS, ES, FS, GS */
+}


### PR DESCRIPTION
I'm not sure why this was never added, to me it seems the most useful feature of the decomposer.  
```
Python>dii()
MOV [RAX+0x20], RSI

Python>pp(de()[0].__dict__)
{   'address': 5392082031L,
    'dt': 2,
    'flags': ['FLAG_DST_WR'],
    'flowControl': 'FC_NONE',
    'instructionBytes': 'H\x89p ',
    'instructionClass': 'ISC_INTEGER',
    'isSegmentDefault': False,
    'meta': 256,
    'mnemonic': 'MOV',
    'modifiedFlags': 0,
    'opcode': 218,
    'operands': [   <distorm3c.Operand object at 0x000001A4919A2400>,
                    <distorm3c.Operand object at 0x000001A4919D7710>],
    'privileged': False,
    'rawFlags': 2624,
    'segment': 255,
    'size': 4,
    'testedFlags': 0,
    'undefinedFlags': 0,
    'unusedPrefixesMask': 0,
    'usedRegistersMask': 65L,
    'valid': True}

Python>distorm.RegisterMasks
{4096: 'RM_CR', 1: 'RM_AX', 2: 'RM_CX', 4: 'RM_DX', 8192: 'RM_DR', 8: 'RM_BX', 128: 'RM_DI', 256: 'RM_FPU', 16: 'RM_SP', 512: 'RM_MMX', 4194304: 'RM_SEG', 524288: 'RM_R13', 32: 'RM_BP', 131072: 'RM_R11', 262144: 'RM_R12', 1024: 'RM_SSE', 16384: 'RM_R8', 1048576: 'RM_R14', 32768: 'RM_R9', 64: 'RM_SI', 2048: 'RM_AVX', 2097152: 'RM_R15', 65536: 'RM_R10'}
```