### PR TITLE
Sfinktah signed imm 32 fix

### DIFF
--- a/python/distorm3/__init__.py
+++ b/python/distorm3/__init__.py
@@ -570,6 +570,7 @@ class Instruction (object):
             self.isSegmentDefault = False
         self.unusedPrefixesMask = di.unusedPrefixesMask
         self.usedRegistersMask = di.usedRegistersMask
+        self.registers = []
 
         if flags == FLAG_NOT_DECODABLE:
             self.mnemonic = 'DB 0x%02x' % (di.imm.byte)
@@ -583,6 +584,10 @@ class Instruction (object):
         for index, flag in enumerate(FLAGS):
             if (flags & (1 << index)) != 0:
                 self.flags.append(flag)
+
+        for mask, value in RegisterMasks.items():
+            if self.usedRegistersMask & mask:
+                self.registers.append(value)
 
         # read the operands
         for operand in di.ops:

--- a/python/distorm3/__init__.py
+++ b/python/distorm3/__init__.py
@@ -23,12 +23,13 @@ __all__ = [
     'Decode64Bits',
     'Mnemonics',
     'Registers',
+    'RegisterMasks'
 ]
 
 from ctypes import *
 import os
 import sys
-from ._generated import Registers, Mnemonics
+from ._generated import Registers, Mnemonics, RegisterMasks
 
 if sys.version_info[0] >= 3:
     xrange = range
@@ -568,6 +569,7 @@ class Instruction (object):
             self.segment = R_NONE
             self.isSegmentDefault = False
         self.unusedPrefixesMask = di.unusedPrefixesMask
+        self.usedRegistersMask = di.usedRegistersMask
 
         if flags == FLAG_NOT_DECODABLE:
             self.mnemonic = 'DB 0x%02x' % (di.imm.byte)

--- a/python/distorm3/_generated.py
+++ b/python/distorm3/_generated.py
@@ -258,3 +258,29 @@ Registers = ["RAX", "RCX", "RDX", "RBX", "RSP", "RBP", "RSI", "RDI", "R8", "R9",
 "YMM0", "YMM1", "YMM2", "YMM3", "YMM4", "YMM5", "YMM6", "YMM7", "YMM8", "YMM9", "YMM10", "YMM11", "YMM12", "YMM13", "YMM14", "YMM15",
 "CR0", "", "CR2", "CR3", "CR4", "", "", "", "CR8",
 "DR0", "DR1", "DR2", "DR3", "", "", "DR6", "DR7"]
+
+RegisterMasks = {
+1: "RM_AX", # /* AL, AH, AX, EAX, RAX */
+2: "RM_CX", # /* CL, CH, CX, ECX, RCX */
+4: "RM_DX", # /* DL, DH, DX, EDX, RDX */
+8: "RM_BX", # /* BL, BH, BX, EBX, RBX */
+0x10: "RM_SP", # /* SPL, SP, ESP, RSP */
+0x20: "RM_BP", # /* BPL, BP, EBP, RBP */
+0x40: "RM_SI", # /* SIL, SI, ESI, RSI */
+0x80: "RM_DI", # /* DIL, DI, EDI, RDI */
+0x100: "RM_FPU", # /* ST(0) - ST(7) */
+0x200: "RM_MMX", # /* MM0 - MM7 */
+0x400: "RM_SSE", # /* XMM0 - XMM15 */
+0x800: "RM_AVX", # /* YMM0 - YMM15 */
+0x1000: "RM_CR", # /* CR0, CR2, CR3, CR4, CR8 */
+0x2000: "RM_DR", # /* DR0, DR1, DR2, DR3, DR6, DR7 */
+0x4000: "RM_R8", # /* R8B, R8W, R8D, R8 */
+0x8000: "RM_R9", # /* R9B, R9W, R9D, R9 */
+0x10000: "RM_R10", # /* R10B, R10W, R10D, R10 */
+0x20000: "RM_R11", # /* R11B, R11W, R11D, R11 */
+0x40000: "RM_R12", # /* R12B, R12W, R12D, R12 */
+0x80000: "RM_R13", # /* R13B, R13W, R13D, R13 */
+0x100000: "RM_R14", # /* R14B, R14W, R14D, R14 */
+0x200000: "RM_R15", # /* R15B, R15W, R15D, R15 */
+0x400000: "RM_SEG", # /* CS, SS, DS, ES, FS, GS */
+}

--- a/src/distorm.c
+++ b/src/distorm.c
@@ -200,7 +200,7 @@ static uint8_t suffixTable[10] = { 0, 'B', 'W', 0, 'D', 0, 0, 0, 'Q' };
 				tmpDisp64 = -di->imm.sbyte;
 				str_int(&str, tmpDisp64);
 			}
-			else str_int(&str, di->imm.qword);
+			else str_uint(&str, di->imm.qword, di->ops[i].size);
 		}
 		else if (type == O_PC) {
 #ifdef SUPPORT_64BIT_OFFSET

--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -81,6 +81,16 @@ void str_int_impl(unsigned char** s, uint64_t x)
 	*s = (unsigned char*)buf;
 }
 
+void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b)
+{
+    uint64_t mask = 0;
+    while (--b) {
+        mask |= 1;
+        mask <<= 1;
+    }
+    str_int_impl(s, x & mask);
+}
+
 #else
 
 void str_int_impl(unsigned char** s, uint8_t src[8])
@@ -109,6 +119,16 @@ void str_int_impl(unsigned char** s, uint8_t src[8])
 	buf[i++] = NIBBLE_TO_CHR;
 
 	*s += (size_t)(i + 2);
+}
+
+void str_uint_impl(unsigned char** s, uint32_t x, uint16_t b)
+{
+    uint32_t mask = 0;
+    while (--b) {
+        mask |= 1;
+        mask <<= 1;
+    }
+    str_int_impl(s, x & mask);
 }
 
 #endif /* SUPPORT_64BIT_OFFSET */

--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -121,16 +121,6 @@ void str_int_impl(unsigned char** s, uint8_t src[8])
 	*s += (size_t)(i + 2);
 }
 
-void str_uint_impl(unsigned char** s, uint32_t x, uint16_t b)
-{
-    uint32_t mask = 0;
-    while (--b) {
-        mask |= 1;
-        mask <<= 1;
-    }
-    str_int_impl(s, x & mask);
-}
-
 #endif /* SUPPORT_64BIT_OFFSET */
 
 #endif /* DISTORM_LIGHT */

--- a/src/textdefs.h
+++ b/src/textdefs.h
@@ -52,7 +52,10 @@ void str_int_impl(unsigned char** s, uint64_t x);
 void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b);
 #else
 #define str_int(s, x) str_int_impl((s), (uint8_t*)&(x))
+# placebo function
+#define str_uint(s, x, b) str_int_impl((s), (uint8_t*)&(x))
 void str_int_impl(unsigned char** s, uint8_t src[8]);
+void str_uint_impl(unsigned char** s, uint8_t src[8], uint16_t b);
 #endif
 
 #endif /* DISTORM_LIGHT */

--- a/src/textdefs.h
+++ b/src/textdefs.h
@@ -47,7 +47,9 @@ void str_hex(_WString* s, const uint8_t* buf, unsigned int len);
 
 #ifdef SUPPORT_64BIT_OFFSET
 #define str_int(s, x) str_int_impl((s), (x))
+#define str_uint(s, x, b) str_uint_impl((s), (x), (b))
 void str_int_impl(unsigned char** s, uint64_t x);
+void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b);
 #else
 #define str_int(s, x) str_int_impl((s), (uint8_t*)&(x))
 void str_int_impl(unsigned char** s, uint8_t src[8]);


### PR DESCRIPTION
reference code:

    BA 5F 60 38 CE                          mov     edx, 0CE38605Fh

distorm3 before:

    MOV EDX, 0xffffffffce38605f

distorm3 after PR:

    MOV EDX, 0xce38605e

change: force immediate values to pass through a bitmask based on size, preventing sign-extended 64-bit values showing up in 32-bit (or other bitsize) locations and causing invalid disassembly.