### PR TITLE
fixed 32-bit -ve imm vals showing in 64-bit #3

### DIFF
--- a/src/distorm.c
+++ b/src/distorm.c
@@ -200,7 +200,7 @@ static uint8_t suffixTable[10] = { 0, 'B', 'W', 0, 'D', 0, 0, 0, 'Q' };
 				tmpDisp64 = -di->imm.sbyte;
 				str_int(&str, tmpDisp64);
 			}
-			else str_int(&str, di->imm.qword);
+			else str_uint(&str, di->imm.qword, di->ops[i].size);
 		}
 		else if (type == O_PC) {
 #ifdef SUPPORT_64BIT_OFFSET

--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -84,9 +84,9 @@ void str_int_impl(unsigned char** s, uint64_t x)
 void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b)
 {
     uint64_t mask = 0;
-    while (--b) {
-        mask |= 1;
+    while (b--) {
         mask <<= 1;
+        mask |= 1;
     }
     str_int_impl(s, x & mask);
 }

--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -81,6 +81,16 @@ void str_int_impl(unsigned char** s, uint64_t x)
 	*s = (unsigned char*)buf;
 }
 
+void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b)
+{
+    uint64_t mask = 0;
+    while (--b) {
+        mask |= 1;
+        mask <<= 1;
+    }
+    str_int_impl(s, x & mask);
+}
+
 #else
 
 void str_int_impl(unsigned char** s, uint8_t src[8])

--- a/src/textdefs.h
+++ b/src/textdefs.h
@@ -47,9 +47,13 @@ void str_hex(_WString* s, const uint8_t* buf, unsigned int len);
 
 #ifdef SUPPORT_64BIT_OFFSET
 #define str_int(s, x) str_int_impl((s), (x))
+#define str_uint(s, x, b) str_uint_impl((s), (x), (b))
 void str_int_impl(unsigned char** s, uint64_t x);
+void str_uint_impl(unsigned char** s, uint64_t x, uint16_t b);
 #else
 #define str_int(s, x) str_int_impl((s), (uint8_t*)&(x))
+# placebo function
+#define str_uint(s, x, b) str_int_impl((s), (uint8_t*)&(x))
 void str_int_impl(unsigned char** s, uint8_t src[8]);
 #endif
 


### PR DESCRIPTION
reference code:

    BA 5F 60 38 CE                          mov     edx, 0CE38605Fh

distorm3 before:

    MOV EDX, 0xffffffffce38605f

distorm3 after PR:

    MOV EDX, 0xce38605e

change: force immediate values to pass through a bitmask based on size, preventing sign-extended 64-bit values showing up in 32-bit (or other bitsize) locations and causing invalid disassembly. 

**note:** _functionality for !SUPPORT_64BIT_OFFSET builds is a placebo (does nothing different)._   i'm not really sure if this is even an issue for such builds.

partial python fix for dealing with pre-PR .dll:

```py
    # where operand is a string with the instruction mnemonic removed
    operands = operand_part.split(',')
    operands = [s.strip() for s in operands]
    for i in range(len(insn_de.operands)):
        operand = operands[i]
        o = insn_de.operands[i]
        if o.value < 0 and o.size == 32 and o.type == 'Immediate':
            operand = "0x%x" % (o.value & 0xffffffff)
    # and where the complete instruction is then assembled as `mnemonic` + `operands`
```