### PR TITLE
stdint wasnt included on 32-bit, _INLINE_ needed to be static; compil…

### DIFF
--- a/include/distorm.h
+++ b/include/distorm.h
@@ -33,29 +33,27 @@ This library is licensed under the BSD license. See the file COPYING.
 	#undef SUPPORT_64BIT_OFFSET
 #endif
 
-/* If your compiler doesn't support stdint.h, define your own 64 bits type. */
-#ifdef SUPPORT_64BIT_OFFSET
-	#ifdef _MSC_VER
-		#define OFFSET_INTEGER unsigned __int64
-	#else
-		#include <stdint.h>
-		#define OFFSET_INTEGER uint64_t
-	#endif
+#ifndef _MSC_VER
+#include <stdint.h>
 #else
-	/* 32 bit offsets are used. */
-	#define OFFSET_INTEGER unsigned long
+/* Since MSVC < 2010 isn't shipped with stdint.h,
+ * here are those from MSVC 2017, which also match
+ * those those in tinycc/libc */
+typedef signed char        int8_t;
+typedef short              int16_t;
+typedef int                int32_t;
+typedef long long          int64_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
 #endif
 
-#ifdef _MSC_VER
-/* Since MSVC isn't shipped with stdint.h, we will have our own: */
-typedef signed __int64		int64_t;
-typedef unsigned __int64	uint64_t;
-typedef signed __int32		int32_t;
-typedef unsigned __int32	uint32_t;
-typedef signed __int16		int16_t;
-typedef unsigned __int16	uint16_t;
-typedef signed __int8		int8_t;
-typedef unsigned __int8		uint8_t;
+#ifdef SUPPORT_64BIT_OFFSET
+#define OFFSET_INTEGER uint64_t
+#else
+/* 32 bit offsets are used. */
+#define OFFSET_INTEGER uint32_t
 #endif
 
 /* Support C++ compilers */

--- a/make/tinycc/Makefile
+++ b/make/tinycc/Makefile
@@ -1,0 +1,34 @@
+#
+# diStorm3 (Linux Port)
+#
+
+TARGET_BASE	= libdistorm3.so
+COBJS	= ../../src/mnemonics.o ../../src/textdefs.o ../../src/prefix.o ../../src/operands.o ../../src/insts.o ../../src/instructions.o ../../src/distorm.o ../../src/decoder.o
+CC	= tcc
+CFLAGS	+= -fPIC -Wall -DSUPPORT_64BIT_OFFSET -DDISTORM_STATIC -std=c99
+LDFLAGS	+= -shared
+PREFIX	= /usr/local
+# The lib SONAME version:
+LIB_S_VERSION = 3
+# The lib real version:
+LIB_R_VERSION = 3.4.0
+LDFLAGS += -Wl,-soname,${TARGET_BASE}.${LIB_S_VERSION}
+DESTDIR	=
+TARGET_NAME = ${TARGET_BASE}.${LIB_R_VERSION}
+
+all: clib
+
+clean:
+	/bin/rm -rf ../../src/*.o ${TARGET_NAME} ../../distorm3.a ./../*.o
+
+clib: ${COBJS}
+	${CC} ${CFLAGS} ${VERSION} ${COBJS} ${LDFLAGS} -o ${TARGET_NAME}
+	tcc -ar rs ../../distorm3.a ${COBJS}
+
+install: ${TARGET_NAME}
+	install -D -s ${TARGET_NAME} ${DESTDIR}${PREFIX}/lib/${TARGET_NAME}
+	ln -sf ${DESTDIR}${PREFIX}/lib/${TARGET_NAME} ${DESTDIR}${PREFIX}/lib/${TARGET_BASE}
+	@echo "... running ldconfig might be smart ..."
+
+.c.o:
+	${CC} ${CFLAGS} ${VERSION} -c $< -o $@

--- a/src/config.h
+++ b/src/config.h
@@ -95,7 +95,7 @@ This library is licensed under the BSD license. See the file COPYING.
 
 #define _DLLEXPORT_
 #define _FASTCALL_
-#define _INLINE_
+#define _INLINE_ static
 
 /* End of __TINYC__ */
 

--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -19,7 +19,7 @@ static uint8_t Nibble2ChrTable[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8
 void str_hex(_WString* s, const uint8_t* buf, unsigned int len)
 {
 	/* 256 * 2 : 2 chars per byte value. */
-	static char* TextBTable =
+	static const char* TextBTable =
 		"000102030405060708090a0b0c0d0e0f" \
 		"101112131415161718191a1b1c1d1e1f" \
 		"202122232425262728292a2b2c2d2e2f" \


### PR DESCRIPTION
These changes were performed to enable tcc/tiny-cc compatibilty, as a pre-cursor to attempting VS 2008 compatibility. Note that tcc supports a minimum of c99. Build tree to follow.

1. stdint wasn't included on 32-bit
2. INLINE needed to be static
3. compile-time char array wasn't const