### PR TITLE
Fix compilation on big-endian systems

### DIFF
--- a/src/textdefs.c
+++ b/src/textdefs.c
@@ -42,7 +42,8 @@ void str_hex(_WString* s, const uint8_t* buf, unsigned int len)
 	s->length = len * 2;
 	s->p[len * 2] = 0;
 	do {
-		RSHORT(&s->p[i]) = RSHORT(&TextBTable[(*buf) * 2]);
+		s->p[i] = TextBTable[(*buf) * 2];
+		s->p[i + 1] = TextBTable[(*buf) * 2 + 1];
 		buf++;
 		i += 2;
 	} while (i < len * 2);


### PR DESCRIPTION
This fixes a compilation issue on big-endian systems:
> D:\buildtrees\distorm\src\3.5.2b-f74091219e.clean\src\textdefs.c(45): error C2106: '=': left operand must be l-value