### PR TITLE
Suppress warning C4819: The file contains a character that cannot be represented in the current code page (932) on Japanese Windows

### DIFF
--- a/src/prefix.c
+++ b/src/prefix.c
@@ -147,8 +147,8 @@ void prefixes_decode(_CodeInfo* ci, _PrefixState* ps)
 		NOTE: AMD treat lock/rep as two different groups... But I am based on Intel.
 
 			- Lock and Repeat:
-				- 0xF0 — LOCK
-				- 0xF2 — REPNE/REPNZ
+				- 0xF0 - LOCK
+				- 0xF2 - REPNE/REPNZ
 				- 0xF3 - REP/REPE/REPZ
 			- Segment Override:
 				- 0x2E - CS


### PR DESCRIPTION
A comment in src/prefix.c contains two '\x97' bytes. They are em dash characters
in single-byte Windows code pages such as 1252. However they are invalid in
Japanese code page.

This PR replaces em dash with hyphen to suppress the warning [C4819](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819).

Without this, compilation using the win32 solution [here](https://github.com/gdabah/distorm/tree/master/make/win32) fails with the following error:
```
1>prefix.c
1>C:\build\distorm\src\prefix.c: error C2220: 警告をエラーとして扱いました。'object' ファイルは生成されません。
1>C:\build\distorm\src\prefix.c: warning C4819: ファイルは、現在のコード ページ (932) で表示できない文字を含んでいます。データの損失を防ぐために、ファイルを Unicode 形式で保存してください
```
(translated to English)
```
1>prefix.c
1>C:\build\distorm\src\prefix.c: error C2220: warning treated as error - no object file generated
1>C:\build\distorm\src\prefix.c: warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss.
```
