### PR TITLE
Add .o, .a, and .so.* to .gitignore for build products.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 *.egg-info
 *.py[cod]
 *.so
+*.so.*
+*.o
+*.a
+*.exe
+*.txe
 build
 dist


### PR DESCRIPTION
Building under linux left build products unignored by git. This change modifies .gitignore to account for Linux gcc build products.